### PR TITLE
Fix player removal bug

### DIFF
--- a/OpenCodeNames/src/io/codenames/serverdata/Game.java
+++ b/OpenCodeNames/src/io/codenames/serverdata/Game.java
@@ -153,13 +153,12 @@ public class Game  implements GameInterface, Serializable {
 
     protected boolean removePlayer(PlayerProxy player){
         String name = player.getName();
-        if(seatsAvailable>0 && playerExists(name)){
-            this.players.remove(name,player);
+        if(playerExists(name)){
+            this.players.remove(name);
             setSeatsAvailable(seatsAvailable+1);
             return true;
-        }else{
-            return false;
         }
+        return false;
 
     }
 


### PR DESCRIPTION
## Summary
- fix logic for removing players from a game so leaving works correctly

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6c5bafc883309f82ad7f38021cdc